### PR TITLE
Remove deprecated maintainers section

### DIFF
--- a/src/grisp_tools.app.src
+++ b/src/grisp_tools.app.src
@@ -15,7 +15,6 @@
     ]},
     {modules, []},
 
-    {maintainers, ["GRiSP Team <grisp@grisp.org>"]},
     {licenses, ["Apache 2.0"]},
     {links, [
         {"GitHub",


### PR DESCRIPTION
Prevents me from publishing to hex.pm.
See https://github.com/hexpm/hex/blob/master/CHANGELOG.md#ignoring-maintainers-field