### PR TITLE
OTP pkg version selection made strict

### DIFF
--- a/src/grisp_tools_step.erl
+++ b/src/grisp_tools_step.erl
@@ -12,7 +12,7 @@
 %--- Macros --------------------------------------------------------------------
 
 -define(RE_VERSION, "
-    (?<VERSION>
+    (?<STRICT>=)?(?<VERSION>
 
 
     (?<MAJOR>\\d+)
@@ -49,12 +49,12 @@ version(#{otp_version_requirement := SVersion} = S0) ->
     {Versions, S1} = available_versions(S0),
     ReOpts = [extended, global, notempty, {capture, all_names, binary}],
     {match, [RawVersion]} = re:run(SVersion, ?RE_VERSION, ReOpts),
-    {Version, Pre, Build, Full} = parse_version(RawVersion),
+    {Version, Pre, Build, Full, Strict} = parse_version(RawVersion),
     Indexed = lists:zip(lists:seq(1, length(Version)), Version),
-    case find_version({Indexed, Pre, Build, Full}, Versions) of
+    case find_version({Indexed, Pre, Build, Full, Strict}, Versions) of
         {error, not_found} ->
             error({otp_version_not_found, SVersion});
-        {ok, {[Major|_Version], _Pre, _Build, FoundFull} = Found} ->
+        {ok, {[Major|_Version], _Pre, _Build, _Strict, FoundFull} = Found} ->
             % TODO: Use the exact OTP_VERSION file here instead?
             % https://erlang.org/doc/system_principles/versions.html
             S2 = case {Major, list_to_integer(erlang:system_info(otp_release))} of
@@ -130,36 +130,36 @@ parse_versions(Output) ->
     ),
     [parse_version(V) || V <- RawVersions].
 
-parse_version([Build, Extra1, Extra2, Major, Minor, Patch, Pre, Full]) ->
+parse_version([Build, Extra1, Extra2, Major, Minor, Patch, Pre, Strict, Full]) ->
     {[I || I <- [
         parse_version_integer(Major),
         parse_version_integer(Minor),
         parse_version_integer(Patch),
         parse_version_integer(Extra1),
         parse_version_integer(Extra2)
-    ], I =/= <<>>], Pre, Build, Full}.
+    ], I =/= <<>>], Pre, Build, case Strict of <<>> -> false; _ -> true end, Full}.
 
 parse_version_integer(<<>>) -> <<>>;
 parse_version_integer(Version) -> binary_to_integer(Version).
 
-find_version_fuzzy({[], _, _, _}, []) ->
+find_version_fuzzy({[], _, _, _, _}, []) ->
     {error, not_found};
-find_version_fuzzy({[], _, _, _}, Versions) ->
+find_version_fuzzy({[], _, _, _, _}, Versions) ->
     {ok, hd(lists:reverse(lists:sort(Versions)))};
-find_version_fuzzy({[{N, V}|Version], Pre, Build, Full}, Versions) ->
+find_version_fuzzy({[{N, V}|Version], Pre, Build, Strict, Full}, Versions) ->
     find_version(
-        {Version, Pre, Build, Full},
+        {Version, Pre, Build, Strict, Full},
         lists:filter(fun
-            ({Ver, P, B, _F}) when P =:= Pre, B =:= Build ->
+            ({Ver, P, B, _Strict, _F}) when P =:= Pre, B =:= Build ->
                 length(Ver) >= N andalso lists:nth(N, Ver) == V;
             (_) ->
                 false
         end, Versions)
     ).
 
-find_version_strict({_VN_list, Pre, Build, Full}, Versions) ->
+find_version_strict({_VN_list, Pre, Build, _Strict, Full}, Versions) ->
     case lists:filter(fun
-            ({_Ver, P, B, VerFullBin}) 
+            ({_Ver, P, B, _S, VerFullBin}) 
               when P =:= Pre, B =:= Build, VerFullBin =:= Full ->
                 true;
             (_) ->
@@ -168,15 +168,13 @@ find_version_strict({_VN_list, Pre, Build, Full}, Versions) ->
         [] -> {error, not_found}
     end.
 
+find_version({_, _, _, Strict, _} = Requested, Availables) when Strict == true ->
+    find_version_strict(Requested, Availables);
 find_version(Requested, Availables) ->
-    case find_version_strict(Requested, Availables) of
-        {ok, V} -> {ok,V};
-        {error, not_found} -> find_version_fuzzy(Requested, Availables)
-    end.
+    find_version_fuzzy(Requested, Availables).
 
-version_list({Version, Pre, Build, _Full}, N, [Last|_] = List) when
-    N > length(Version)
-->
+version_list({Version, Pre, Build, _Strict, _Full}, N, [Last|_] = List) 
+  when N > length(Version) ->
     Extra = case {Pre, Build} of
         {<<>>, <<>>} -> [];
         {Pre, <<>>} -> [iolist_to_binary([Last, "-", Pre])];
@@ -184,7 +182,7 @@ version_list({Version, Pre, Build, _Full}, N, [Last|_] = List) when
         {Pre, Build} -> [iolist_to_binary([Last, "-", Pre, "+", Build])]
     end,
     lists:reverse(Extra ++ List);
-version_list({Version, _Pre, _Build, _Full} = Ver, N, List) ->
+version_list({Version, _Pre, _Build, _Strict, _Full} = Ver, N, List) ->
     Components = [integer_to_list(V) || V <- lists:sublist(Version, N)],
     Intermediate = iolist_to_binary(string:join(Components, ".")),
     version_list(Ver, N + 1, [Intermediate|List]).

--- a/src/grisp_tools_step.erl
+++ b/src/grisp_tools_step.erl
@@ -142,20 +142,16 @@ parse_version([Build, Extra1, Extra2, Major, Minor, Patch, Pre, Full]) ->
 parse_version_integer(<<>>) -> <<>>;
 parse_version_integer(Version) -> binary_to_integer(Version).
 
-find_version({[], _, _, _}, []) ->
-    {error, not_found};
-find_version({[], _, _, _}, Versions) ->
-    {ok, hd(lists:reverse(lists:sort(Versions)))};
-find_version({[{N, V}|Version], Pre, Build, Full}, Versions) ->
-    find_version(
-        {Version, Pre, Build, Full},
-        lists:filter(fun
-            ({Ver, P, B, _F}) when P =:= Pre, B =:= Build ->
-                length(Ver) >= N andalso lists:nth(N, Ver) == V;
+find_version({_VN_list, Pre, Build, Full}, Versions) ->
+    case lists:filter(fun
+            ({_Ver, P, B, VerFullBin}) 
+              when P =:= Pre, B =:= Build, VerFullBin =:= Full ->
+                true;
             (_) ->
-                false
-        end, Versions)
-    ).
+                false end, Versions) of
+        [V|_] -> {ok, V};
+        [] -> {error, not_found}
+    end.
 
 version_list({Version, Pre, Build, _Full}, N, [Last|_] = List) when
     N > length(Version)

--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -97,10 +97,10 @@ paths(Root, Platform, Version) ->
         package_cache => cache(package)
     }.
 
-otp_dir(Root, Platform, {_Components, _Pre, _Build, Ver}) ->
+otp_dir(Root, Platform, {_Components, _Pre, _Build, _Strict, Ver}) ->
     filename:join([Root, "_grisp", Platform, "otp", Ver]).
 
-package_name(#{otp_version := {_, _, _, OTPVersion}, build := #{hash := #{value := Hash}}}) ->
+package_name(#{otp_version := {_, _, _, _, OTPVersion}, build := #{hash := #{value := Hash}}}) ->
     iolist_to_binary(["grisp_otp_build_", OTPVersion, "_", Hash, ".tar.gz"]).
 
 package_cache_temp(State) ->

--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -97,10 +97,10 @@ paths(Root, Platform, Version) ->
         package_cache => cache(package)
     }.
 
-otp_dir(Root, Platform, {_Components, _Pre, _Build, _Strict, Ver}) ->
+otp_dir(Root, Platform, {_Components, _Pre, _Build, Ver}) ->
     filename:join([Root, "_grisp", Platform, "otp", Ver]).
 
-package_name(#{otp_version := {_, _, _, _, OTPVersion}, build := #{hash := #{value := Hash}}}) ->
+package_name(#{otp_version := {_, _, _, OTPVersion}, build := #{hash := #{value := Hash}}}) ->
     iolist_to_binary(["grisp_otp_build_", OTPVersion, "_", Hash, ".tar.gz"]).
 
 package_cache_temp(State) ->


### PR DESCRIPTION
This is not a fix but rather a simplification.

I just search a perfect matching version in the available package list.

This is a simpler function in respect to the previous 'find_version'.

If we want to have both: strict selection & minor version search, 
we would need to define a way for the user to specify it in the rebar.config.