### PR TITLE
Different build, install, and package path selected on custom_build flag

### DIFF
--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -90,16 +90,16 @@ cdn_path(otp, #{platform := Platform} = State) ->
 
 paths(Root, Platform, Version, _Hash, _CustomBuild = true) ->
     Dir = otp_dir(Root, Platform, Version),
-    sub_paths(Dir, "");
+    sub_paths([Dir]);
 paths( _, Platform, {_Components, _Pre, _Build, Ver}, Hash, _CustomBuild = false) ->
     Dir = filename:join([cache(), Platform, "otp", Ver]),    
-    sub_paths(Dir, Hash).
+    sub_paths([Dir, Hash]).
 
-sub_paths(Dir, Hash) ->
+sub_paths(Dir) ->
     #{
-        build => filename:join([Dir, Hash, "build"]),
-        install => filename:join([Dir, Hash, "install"]),
-        package => filename:join([Dir, Hash, "package"]),
+        build => filename:join(Dir ++ ["build"]),
+        install => filename:join(Dir ++ ["install"]),
+        package => filename:join(Dir ++ ["package"]),
         package_cache => cache(package)
     }.
 

--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -8,7 +8,7 @@
 -export([exec/3]).
 -export([env/1]).
 -export([cdn_path/2]).
--export([paths/3]).
+-export([paths/5]).
 -export([package_name/1]).
 -export([package_cache_temp/1]).
 -export([package_cache_file/1]).
@@ -88,12 +88,18 @@ cdn_path(otp, #{platform := Platform} = State) ->
     Path = lists:join($/, ["platforms", atom_to_binary(Platform), "otp", File]),
     uri_string:resolve(Path, [env(cdn), "/"]).
 
-paths(Root, Platform, Version) ->
+paths(Root, Platform, Version, _Hash, _CustomBuild = true) ->
     Dir = otp_dir(Root, Platform, Version),
+    sub_paths(Dir, "");
+paths( _, Platform, {_Components, _Pre, _Build, Ver}, Hash, _CustomBuild = false) ->
+    Dir = filename:join([cache(), Platform, "otp", Ver]),    
+    sub_paths(Dir, Hash).
+
+sub_paths(Dir, Hash) ->
     #{
-        build => filename:join(Dir, "build"),
-        install => filename:join(Dir, "install"),
-        package => filename:join(Dir, "package"),
+        build => filename:join([Dir, Hash, "build"]),
+        install => filename:join([Dir, Hash, "install"]),
+        package => filename:join([Dir, Hash, "package"]),
         package_cache => cache(package)
     }.
 


### PR DESCRIPTION
This is the new directory where pre-compiled builds are extracted/installed
ziopio@LUCA-PC:~/.cache/grisp$ tree -L 5
.
├── grisp2
│---└── otp
│-----└── 23.3.4.11
│-------└── install
│----------├── GRISP_PACKAGE_FILES
│----------├── GRISP_TOOLCHAIN_REVISION
│----------├── Install
│----------├── bin
│----------├── erts-11.2.2.10
│----------├── lib
│----------├── releases
│----------└── usr
└── packages
--└── otp
------├── grisp_otp_build_23.3.4.11_a80bccc41bebe9f21b8623d29b0c801277928295ab1f81531e37b2eb5353521e.tar.gz