### PR TITLE
Implement report command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- Implementation of the `report` command: [#74](https://github.com/grisp/rebar3_grisp/pull/74)
+
 ## [2.4.0] - 2022-07-18
 
 ### Added

--- a/src/grisp_tools.erl
+++ b/src/grisp_tools.erl
@@ -6,6 +6,7 @@
 -export([build/1]).
 -export([deploy/1]).
 -export([list_packages/1]).
+-export([report/1]).
 
 %--- API -----------------------------------------------------------------------
 
@@ -24,3 +25,5 @@ build(Configuration) -> grisp_tools_build:run(Configuration).
 deploy(State) -> grisp_tools_deploy:run(State).
 
 list_packages(Opts) -> grisp_tools_package:list(Opts).
+
+report(Opts) -> grisp_tools_report:run(Opts).

--- a/src/grisp_tools_report.erl
+++ b/src/grisp_tools_report.erl
@@ -28,7 +28,6 @@ run(State) ->
 
 %--- Tasks ---------------------------------------------------------------------
 
-
 clean(#{flags := #{tar := true}} = S0) -> S0;
 clean(#{report_dir := ReportDir} = S0) ->
     Cmd = lists:append(["rm -r ", ReportDir, " "]),
@@ -55,7 +54,8 @@ tar(#{report_dir := ReportDir, flags := #{tar := true}} = S0) ->
             {{ok, _Res}, S1} = shell(S0, Cmd),
             event(S1, [TarFile])
     end.
-% helpers ----------------------------------------------------------------------
+
+%--- Internal ------------------------------------------------------------------
 
 project_settings(S0) ->
     S1 = copy_project_file("rebar.config", S0),
@@ -84,9 +84,6 @@ build_overlay(#{
     BuildOverlay2 = strip_absolute_paths(BuildOverlay, ProjectForlder),
     file:write_file(BuildInfo, io_lib:format("~p~n", [BuildOverlay2])),
     event(S, [write, BuildInfo]).
-
-
-% Helpers
 
 copy_project_file(Filename, #{project_root := Root, report_dir := ReportDir} = S0) ->
     Src = filename:join(Root, Filename),

--- a/src/grisp_tools_report.erl
+++ b/src/grisp_tools_report.erl
@@ -34,14 +34,17 @@ clean(#{report_dir := ReportDir} = S0) ->
     {_, S1} = shell(S0, Cmd, [return_on_error]),
     S1.
 
-write_report(#{flags := #{tar := true}} = S0) -> event(S0, [skip]);
-write_report(#{report_dir := ReportDir} = S0) ->
-    S1 = grisp_tools_util:pipe(S0, [
-        fun hash_index/1,
-        fun build_overlay/1,
-        fun project_settings/1
-    ]),
-    event(S1, [{new_report, ReportDir}]).
+write_report(#{report_dir := ReportDir, flags := #{tar := Tar}} = S0) ->
+    case {filelib:is_dir(ReportDir), Tar} of
+        {true, true} -> event(S0, [skip]);
+        _ ->
+            S1 = grisp_tools_util:pipe(S0, [
+                fun hash_index/1,
+                fun build_overlay/1,
+                fun project_settings/1
+            ]),
+            event(S1, [{new_report, ReportDir}])
+    end.
 
 tar(#{flags := #{tar := false}} = S0) -> S0;
 tar(#{report_dir := ReportDir, flags := #{tar := true}} = S0) ->

--- a/src/grisp_tools_report.erl
+++ b/src/grisp_tools_report.erl
@@ -113,5 +113,4 @@ strip_absolute_paths(Term, _) ->
     Term.
 
 format_datetime() ->
-    {{Y,Mo,W},{H,Mi,S}} = calendar:local_time(),
-    io_lib:format("~p-~p-~p_~p-~p-~p", [Y, Mo, W, H, Mi, S]).
+    calendar:system_time_to_rfc3339(erlang:system_time(second)).

--- a/src/grisp_tools_report.erl
+++ b/src/grisp_tools_report.erl
@@ -1,0 +1,97 @@
+-module(grisp_tools_report).
+
+% API
+-export([run/1]).
+
+-import(grisp_tools_util, [event/2]).
+-import(grisp_tools_util, [shell/2]).
+-import(grisp_tools_util, [shell/3]).
+-import(grisp_tools_util, [ensure_dir/1]).
+-import(grisp_tools_util, [write_file/3]).
+
+%--- API -----------------------------------------------------------------------
+
+run(State) ->
+    grisp_tools_util:weave(State, [
+        fun grisp_tools_step:config/1,
+        {report, [
+            fun clean/1,
+            fun project_settings/1,
+            {validate, [
+                fun grisp_tools_step:apps/1,
+                fun grisp_tools_step:version/1
+            ]},
+            fun grisp_tools_step:collect/1,
+            fun hash_index/1,
+            fun build_overlay/1,
+            fun tar/1
+        ]}
+    ]).
+
+%--- Tasks ---------------------------------------------------------------------
+
+clean(#{report_dir := ReportDir} = S0) ->
+    Cmd = lists:append(["rm -r ", ReportDir, " "]),
+    {_, S1} = shell(S0, Cmd, [return_on_error]),
+    event(S1, [info, ReportDir]).
+
+project_settings(S0) ->
+    S1 = copy_project_file("rebar.config", S0),
+    copy_project_file("rebar.lock", S1).
+
+hash_index(#{
+    report_dir := ReportDir,
+    build := #{
+        hash := Hash
+}} = S) ->
+    HashInfo = filename:join(ReportDir, "hash.txt"),
+    ensure_dir(HashInfo),
+    file:write_file(HashInfo, io_lib:format("~p~n", [Hash])),
+    event(S, [write, HashInfo]).
+
+build_overlay(#{
+    project_root := Project_root,
+    report_dir := ReportDir,
+    build := #{
+        overlay := BuildOverlay
+    }} = S)  ->
+    BuildInfo = filename:join(ReportDir, "build_overlay.txt"),
+    ensure_dir(BuildInfo),
+    ProjectForlder = list_to_binary(filename:basename(
+                                                filename:dirname(Project_root))),
+    BuildOverlay2 = strip_absolute_paths(BuildOverlay, ProjectForlder),
+    file:write_file(BuildInfo, io_lib:format("~p~n", [BuildOverlay2])),
+    event(S, [write, BuildInfo]).
+
+tar(#{flags := #{tar := false}} = S0) -> S0;
+tar(#{report_dir := ReportDir, flags := #{tar := true}} = S0) ->
+    TarFile = filename:join(filename:dirname(ReportDir), "report.tar.gz"),
+    Cmd = lists:append(["tar -czvf ", TarFile, " -C ", ReportDir, " ."]),
+    {{ok, _Res}, S1} = shell(S0, Cmd),
+    event(S1, [TarFile]).
+
+% Helpers
+
+copy_project_file(Filename, #{project_root := Root, report_dir := ReportDir} = S0) ->
+    Src = filename:join(Root, Filename),
+    Dst = filename:join(ReportDir, Filename),
+    Copy = #{source => Src, target => Dst},
+    try
+            write_file(Root, Copy, #{}),
+            event(S0, [files, {copy, Dst}])
+        catch error:_ ->
+            event(S0, [files, {missing, Src}])
+    end.
+
+strip_absolute_paths({_Term, Binary}, Seam) when is_binary(Binary) ->
+    {_Term, strip_absolute_paths(Binary, Seam)};
+strip_absolute_paths(Term, Seam) when is_binary(Term) ->
+    case binary:split(Term, Seam) of
+        [_RootPath, InnerPath] -> iolist_to_binary([Seam, InnerPath]);
+        [Skipped] -> Skipped
+    end;
+strip_absolute_paths(Term, Seam) when is_map(Term) ->
+    maps:from_list([ {K, strip_absolute_paths(V, Seam)} || {K,V}
+                                                        <- maps:to_list(Term)]);
+strip_absolute_paths(Term, _) ->
+    Term.

--- a/src/grisp_tools_report.erl
+++ b/src/grisp_tools_report.erl
@@ -30,9 +30,11 @@ run(State) ->
 
 clean(#{flags := #{tar := true}} = S0) -> S0;
 clean(#{report_dir := ReportDir} = S0) ->
-    Cmd = lists:append(["rm -r ", ReportDir, " "]),
+    Cmd = lists:append(["rm -r ", ReportDir]),
     {_, S1} = shell(S0, Cmd, [return_on_error]),
-    S1.
+    Cmd2 = lists:append(["rm ", ReportDir, ".tar.gz"]),
+    {_, S2} = shell(S1, Cmd2, [return_on_error]),
+    S2.
 
 write_report(#{flags := #{tar := true}} = S0) -> event(S0, [skip]);
 write_report(#{report_dir := ReportDir} = S0) ->
@@ -49,7 +51,7 @@ tar(#{report_dir := ReportDir, flags := #{tar := true}} = S0) ->
         false ->
             event(S0, [{error, no_report}]);
         true ->
-            TarFile = filename:join(filename:dirname(ReportDir), "report.tar.gz"),
+            TarFile = ReportDir ++ ".tar.gz",
             Cmd = lists:append(["tar -czvf ", TarFile, " -C ", ReportDir, " ."]),
             {{ok, _Res}, S1} = shell(S0, Cmd),
             event(S1, [TarFile])

--- a/src/grisp_tools_step.erl
+++ b/src/grisp_tools_step.erl
@@ -185,7 +185,7 @@ find_version(Requested, fuzzy, Availables) ->
 
 find_version_strict({_VN_list, Pre, Build, Full}, Versions) ->
     case lists:filter(fun
-            ({_Ver, P, B, VerFullBin}) 
+            ({_Ver, P, B, VerFullBin})
               when P =:= Pre, B =:= Build, VerFullBin =:= Full ->
                 true;
             (_) ->
@@ -209,7 +209,7 @@ find_version_fuzzy({[{N, V}|Version], Pre, Build, Full}, Versions) ->
         end, Versions)
     ).
 
-version_list({Version, Pre, Build, _Full}, N, [Last|_] = List) 
+version_list({Version, Pre, Build, _Full}, N, [Last|_] = List)
   when N > length(Version) ->
     Extra = case {Pre, Build} of
         {<<>>, <<>>} -> [];


### PR DESCRIPTION
The command creates a directory with the following files.
These 4 files allow us to understand what is happening if an unexpected has is generate.
`rebar.config` and `reba.lock` allow us to reproduce the error.
`hash.txt `and `build_overlay.txt` give information on the files that matter in hash calculations.
Knowing their position, app and hash value gives us a clear picture of the user grisp-build-enviroment.
```
_grisp
├── report
│   ├── build_overlay.txt
│   ├── hash.txt
│   ├── rebar.config
│   └── rebar.lock
└── report.tar.gz
```
If runned with --tar, the plugin attempts to pack the directory content without overwriting anything.
This gives the opportunity to the user to edit such files before creating a tar.
Requires https://github.com/grisp/rebar3_grisp/pull/74
## Objective
The idea is to ask the user to provide such tarball as a way of skipping questions and speed-up support.