### PR TITLE
Support for toolchain docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ## Added
 
 - Implementation of the `report` command: [#74](https://github.com/grisp/rebar3_grisp/pull/74)
+- Support for docker toolchains [#20](https://github.com/grisp/grisp_tools/pull/20)
 
 ## [2.4.0] - 2022-07-18
 

--- a/src/grisp_tools_build.erl
+++ b/src/grisp_tools_build.erl
@@ -55,13 +55,12 @@ run(Configuration) ->
 
 %--- Internal Steps ------------------------------------------------------------
 
-build(#{build := #{flags := #{docker := true}}} = S0) ->
+build(#{paths := #{toolchain := {docker, _Image}}} = S0) ->
     % Skip setting envs that are already in the docker image
     S1 = event(S0, [{platform, maps:get(platform, S0)}]),
     mapz:deep_merge(S1, #{shell => #{env => #{}}});
-build(S0) ->
+build(#{paths := #{toolchain := {directory, ToolchainRoot}}} = S0) ->
     S1 = event(S0, [{platform, maps:get(platform, S0)}]),
-    ToolchainRoot = mapz:deep_get([paths, toolchain], S1),
     PATH = os:getenv("PATH"),
     Env = #{
         "GRISP_TC_ROOT" => ToolchainRoot,
@@ -201,11 +200,16 @@ install(S0) ->
 
     grisp_tools_util:ensure_dir(filename:join(InstallPath, ".")),
     S1 = grisp_tools_util:pipe(S0, [
-        fun(S) -> shell_ok(S, ["rm -rf ", filename:join(InstallPath, "*")], [{cd, InstallPath}]) end,
-        fun(S) -> shell_ok(S, ["make install DESTDIR=", $", InstallPath, $"], [{cd, BuildPath}]) end
+        fun(S) -> shell_ok(S,
+                           ["rm -rf ", filename:join(InstallPath, "*")],
+                           [{cd, InstallPath}]) end,
+        fun(S) -> shell_ok(S,
+                           ["make install DESTDIR=", $", InstallPath, $"],
+                           [{cd, BuildPath}]) end
     ]),
 
-    [ERTS] = filelib:wildcard(to_list(filename:join(InstallPath, "lib/erlang/erts-*"))),
+    [ERTS] = filelib:wildcard(to_list(filename:join(InstallPath,
+                                                    "lib/erlang/erts-*"))),
     Ver = lists:last(string:split(ERTS, "-", trailing)),
 
     S2 = mapz:deep_merge(S1, #{shell => #{env => #{
@@ -215,23 +219,22 @@ install(S0) ->
 
     run_hooks(S2, post_install, [{cd, InstallPath}]).
 
-post(#{build := #{hash := #{index := Index},
-                  flags := #{docker := UseDocker}}} = S0) ->
-    PackageListing = filename:join(mapz:deep_get([paths, install], S0), "GRISP_PACKAGE_FILES"),
+post(#{build := #{hash := #{index := Index}}} = S0) ->
+    PackageListing = filename:join(mapz:deep_get([paths, install], S0),
+                                   "GRISP_PACKAGE_FILES"),
     ok = file:write_file(PackageListing, grisp_tools_util:build_hash_format(Index)),
 
-    % info("Copying revision string into install dir"),
     InstallPath = mapz:deep_get([paths, install], S0),
     RevDestination = filename:join(InstallPath, "GRISP_TOOLCHAIN_REVISION"),
-    case UseDocker of
-        false ->
-            ToolchainRoot = mapz:deep_get([paths, toolchain], S0),
+    Toolchain = mapz:deep_get([paths, toolchain], S0),
+    case Toolchain of
+        {directory, ToolchainRoot} ->
             RevSource = filename:join([ToolchainRoot, "GRISP_TOOLCHAIN_REVISION"]),
             case file:copy(RevSource, RevDestination) of
                 {ok, _} -> S0;
                 _ -> error({missing_toolchain_revision, RevSource})
             end;
-        true ->
+        {docker, _Image} ->
             Cmd = "cat /grisp2-rtems-toolchain/rtems/5/GRISP_TOOLCHAIN_REVISION",
             DockerCmd = dockerize_command(Cmd, S0),
             {{ok, RevisionString}, S1} = shell(S0, DockerCmd, []),
@@ -249,37 +252,43 @@ tar(#{build := #{flags := #{tar := true}}} = S0) ->
 tar(S0) ->
     event(S0, ['_skip']).
 
-build_step(Command, Opts, #{build := #{flags := #{docker := true}}} = S0) ->
-    NewCommand = dockerize_command(Command, S0),
-    {{ok, Output}, State1} = shell(S0, NewCommand, Opts),
-    event(State1, [{output, Output}]);
-build_step(Command, Opts, State0) ->
-    {{ok, Output}, State1} = shell(State0, Command, Opts),
+build_step(Command, Opts, S0) ->
+    Toolchain = mapz:deep_get([paths, toolchain], S0),
+    ShellCmd = case Toolchain of
+        {docker, _} -> dockerize_command(Command, S0);
+        {directory, _ } -> Command
+    end,
+    {{ok, Output}, State1} = shell(S0, ShellCmd, Opts),
     event(State1, [{output, Output}]).
 
 %--- Internal ------------------------------------------------------------------
 
-dockerize_command(Cmd, #{shell := #{env := Env}} = S0) ->
+dockerize_command(Cmd, S0) ->
     {ok, Cwd} = file:get_cwd(),
+    Env = mapz:deep_get([shell, env], S0),
     BuidPath = binary_to_list(mapz:deep_get([paths, build], S0)),
+    {docker, Image} = mapz:deep_get([paths, toolchain], S0),
     BuildSubdir = string:prefix(BuidPath, Cwd),
     ["docker run",
-    [" -e " ++ K ++ "=" ++ io_lib:format("~s", [V])|| {K,V} <- maps:to_list(Env)],
+    [" -e " ++ K ++ "=" ++ io_lib:format("~s",[V])|| {K,V} <- maps:to_list(Env)],
     " --volume " ++ Cwd ++ ":" ++ Cwd,
-    " grisp/grisp2-rtems-toolchain sh -c \"cd " ++ Cwd ++ BuildSubdir,
+    " " ++ Image ++ " sh -c \"cd " ++ Cwd ++ BuildSubdir,
     " && " , Cmd, "\""].
 
 apply_patch({Name, Patch}, State0) ->
     Dir = mapz:deep_get([paths, build], State0),
     Context = mapz:deep_get([build, context], State0),
     grisp_tools_util:write_file(Dir, Patch, Context),
-    State4 = case shell(State0, ["git apply ", Name, " --ignore-whitespace --reverse --check"],
-            [{cd, Dir}, return_on_error]) of
+    State4 = case shell(State0,
+                ["git apply ", Name, " --ignore-whitespace --reverse --check"],
+                [{cd, Dir}, return_on_error]) of
         {{ok, _Output}, State1} ->
             event(State1, [{skip, Patch}]);
         {{error, {1, _}}, State1} ->
             State2 = event(State1, [{apply, Patch}]),
-            {{ok, _}, State3} = shell(State2, "git apply --ignore-whitespace " ++ Name, [{cd, Dir}]),
+            {{ok, _}, State3} = shell(State2,
+                                      "git apply --ignore-whitespace " ++ Name,
+                                      [{cd, Dir}]),
             State3
     end,
     {{ok, _}, State5} = shell(State4, "rm " ++ Name, [{cd, Dir}]),
@@ -301,7 +310,7 @@ copy_file(Root, File, State0) ->
     grisp_tools_util:write_file(Root, File, Context),
     State1.
 
-run_hooks(#{build := #{flags := #{docker := UseDocker}}} = S0, Type, Opts) ->
+run_hooks(#{paths := #{toolchain := {ToolchainType, _}}} = S0, Type, Opts) ->
     Hooks = mapz:deep_get([build, overlay, hooks, Type], S0, []),
     case maps:size(Hooks) of
         0 ->
@@ -310,9 +319,9 @@ run_hooks(#{build := #{flags := #{docker := UseDocker}}} = S0, Type, Opts) ->
             S1 = event(S0, [hook, Type]),
             lists:foldl(fun({_Name, #{source := Source} = Hook}, S2) ->
                 S3 = event(S2, [hook, Type, {run, Hook}]),
-                Cmd = case UseDocker of
-                    true -> dockerize_command(Source, S0);
-                    false -> Source
+                Cmd = case ToolchainType of
+                    docker -> dockerize_command(Source, S0);
+                    directory -> Source
                 end,
                 shell_ok(S3, Cmd, Opts)
             end, S1, lists:sort(maps:to_list(Hooks)))

--- a/src/grisp_tools_build.erl
+++ b/src/grisp_tools_build.erl
@@ -266,7 +266,7 @@ dockerize_command(Cmd, #{shell := #{env := Env}} = S0) ->
     ["docker run",
     [" -e " ++ K ++ "=" ++ io_lib:format("~s", [V])|| {K,V} <- maps:to_list(Env)],
     " --volume " ++ Cwd ++ ":" ++ Cwd,
-    " grisp2-rtems-toolchain sh -c \"cd " ++ Cwd ++ BuildSubdir,
+    " grisp/grisp2-rtems-toolchain sh -c \"cd " ++ Cwd ++ BuildSubdir,
     " && " , Cmd, "\""].
 
 apply_patch({Name, Patch}, State0) ->

--- a/src/grisp_tools_build.erl
+++ b/src/grisp_tools_build.erl
@@ -250,7 +250,6 @@ tar(S0) ->
 
 build_step(Command, Opts, #{build := #{flags := #{docker := true}}} = S0) ->
     NewCommand = dockerize_command(Command, S0),
-    io:format("Final Cmd: ~p~n",[NewCommand]),
     {{ok, Output}, State1} = shell(S0, NewCommand, Opts),
     event(State1, [{output, Output}]);
 build_step(Command, Opts, State0) ->

--- a/src/grisp_tools_build.erl
+++ b/src/grisp_tools_build.erl
@@ -56,6 +56,7 @@ run(Configuration) ->
 %--- Internal Steps ------------------------------------------------------------
 
 build(#{build := #{flags := #{docker := true}}} = S0) ->
+    % Skip setting envs that are already in the docker image
     S1 = event(S0, [{platform, maps:get(platform, S0)}]),
     mapz:deep_merge(S1, #{shell => #{env => #{}}});
 build(S0) ->

--- a/src/grisp_tools_step.erl
+++ b/src/grisp_tools_step.erl
@@ -123,9 +123,8 @@ collect(#{project_root := Root, platform := Platform,
     }),
     mapz:deep_put([build, hash], #{value => Hash, index => HashIndex}, S3).
 
-toolchain(#{build := #{flags := #{docker := true}}} = S0) -> S0;
-toolchain(S0) ->
-    ToolchainRoot = mapz:deep_get([paths, toolchain], S0),
+toolchain(#{paths := #{toolchain := {docker, _}}} = S0) -> S0;
+toolchain(#{paths := #{toolchain := {directory, ToolchainRoot}}} = S0) ->
     [error({toolchain_root_invalid, ToolchainRoot}) || not filelib:is_dir(ToolchainRoot)],
     Files = [
         ["GRISP_TOOLCHAIN_REVISION"],

--- a/src/grisp_tools_step.erl
+++ b/src/grisp_tools_step.erl
@@ -123,6 +123,7 @@ collect(#{project_root := Root, platform := Platform,
     }),
     mapz:deep_put([build, hash], #{value => Hash, index => HashIndex}, S3).
 
+toolchain(#{build := #{flags := #{docker := true}}} = S0) -> S0;
 toolchain(S0) ->
     ToolchainRoot = mapz:deep_get([paths, toolchain], S0),
     [error({toolchain_root_invalid, ToolchainRoot}) || not filelib:is_dir(ToolchainRoot)],

--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -95,7 +95,7 @@ paths(Root, Platform, {_Components, _Pre, _Build, Ver}, _Hash, _CustomBuild = tr
     Dir = filename:join(otp_checkout_dir(Root, Platform), Ver),
     sub_paths([Dir], Platform);
 paths( _, Platform, {_Components, _Pre, _Build, Ver}, Hash, _CustomBuild = false) ->
-    Dir = filename:join([cache(), Platform, "otp", Ver]),    
+    Dir = filename:join([cache(), Platform, "otp", Ver]),
     sub_paths([Dir, Hash], Platform).
 
 otp_checkout_dir(Root, Platform) ->


### PR DESCRIPTION
Why?
With this we have a parachute in case toolchain compilation is broken and some random user needs to be able to build OTP for him/her-self.

This feature requires the docker engine to be up and running.

It expects a docker image tagged `grisp2-rtems-toolchain` to be available.
The image must contain a built toolchain under `/grisp2-rtems-toolchain/rtems/5 `and have `GRISP_TC_ROOT` and `PATH` environment variables set accordingly.

The idea here is to use docker just to run toolchain related commands and leave all other stuff to the host erlang and rebar3 installations. That said, this feature needs to mount the project directory as a docker volume inside the container. 

To make stuff more simple, the mounted volume has (in the container) the same identical path of the working dir on the host. This will be a problem if we run in a Windows file system.

Here the experimental dockerfile, the image is 6.48 GB and can certainly be lighter although the toolchain alone is pretty big.

```
FROM ubuntu:latest

RUN set -xe \
    && apt-get update \
    && baseDeps='ca-certificates git unzip' \
    && apt-get install -y --no-install-recommends $baseDeps \
    && toolchainDeps='build-essential flex bison cmake texinfo device-tree-compiler u-boot-tools lzop libusb-1.0-0-dev python3 python-is-python3 libpython3-dev python3-dev' \
    && apt-get install -y --no-install-recommends $toolchainDeps

RUN git clone https://github.com/grisp/grisp2-rtems-toolchain

WORKDIR /grisp2-rtems-toolchain

RUN  make install

WORKDIR /

RUN set -xe \
    && apt purge -y --auto-remove $toolchainDeps \
    && apt purge -y --auto-remove $baseDeps

ENV GRISP_TC_ROOT /grisp2-rtems-toolchain/rtems/5
ENV PATH $GRISP_TC_ROOT/bin:$PATH
```
