### PR TITLE
Removed quotes from default prompt and improved some wording

### DIFF
--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -82,7 +82,8 @@ validate_user_choice(State, name) ->
     case {Interactive, filelib:is_dir(ProjectPath)} of
         {true, true} ->
             Prompt = io_lib:format(
-                       "A directory with the name ~p already exists. Do you wish to proceed ?",
+                       "A directory with the name ~p already exists."
+                       ++ "Do you wish to proceed ?",
                        [ProjectName]),
             UserChoice = grisp_tools_io:ask(State, Prompt, boolean, false),
             case UserChoice of
@@ -103,8 +104,8 @@ settings() ->
       "Activates the interactive mode"},
      {"Description", {desc, undefined}, {string, "A GRiSP application"},
       "Short description of the app"},
-     {"Copyright year", {copyright_year, undefined}, {string, Year},
-      "The copyright year"},
+     {"Copyright year", {copyright_year, undefined},
+      {string, integer_to_list(Year)}, "The copyright year"},
      {"Author name", {author_name, undefined}, {string, AuthorName},
       "The name of the author"},
      {"Author email", {author_email, undefined}, {string, AuthorEmail},

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -9,12 +9,16 @@
 % {Name, {Long, Short}, {Type, Default}, Description}
 -type settings() :: {string(),
                      {string(), char()},
-                     {string, string()} | {boolean, boolean()},
+                     {string, string()}
+                     | {boolean, boolean()}
+                     | {latin1, string()},
                      string()}.
 
 -type settings_options() :: {string(),
                              {string(), char()},
-                             {string, string()} | {boolean, boolean()},
+                             {string, string()}
+                             | {boolean, boolean()}
+                             | {latin1, string()},
                              string(),
                              function()} | settings().
 
@@ -109,7 +113,7 @@ settings() ->
 
 -spec settings_options() -> [settings_options()].
 settings_options() -> [
-    {"App name", {name, undefined}, {string, "robot"},
+    {"App name", {name, undefined}, {latin1, "robot"},
      "The name of the OTP application"},
     {"Erlang version", {otp_version, $o}, {string, "25"},
      "The OTP version of the GRiSP app"},

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -92,7 +92,7 @@ settings_options() -> [
 
 -spec network_options() -> [settings_options()].
 network_options() -> [
-    {"Use Wifi ?", {wifi, $w}, {boolean, false},
+    {"Use Wi-Fi ?", {wifi, $w}, {boolean, false},
      "Wifi configuration", fun wifi_options/0},
     {"Enable GRiSP.io integration ?", {grisp_io, $g}, {boolean, false},
      "GRiSP.io configuration", fun grisp_io_options/0},
@@ -102,8 +102,8 @@ network_options() -> [
 
 -spec wifi_options() -> [settings_options()].
 wifi_options() -> [
-    {"Wifi Name", {ssid, $p}, {string, "My Wifi"}, "The SSID of your Wifi"},
-    {"Wifi Password", {psk, $p}, {string, "..."}, "The PSK of your Wifi"}
+    {"Wi-Fi SSID", {ssid, $p}, {string, "My Wifi"}, "The SSID of your Wi-Fi"},
+    {"Wi-Fi Password", {psk, $p}, {string, "..."}, "The PSK of your Wi-Fi"}
 ].
 
 -spec grisp_io_options() -> [settings_options()].

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -82,8 +82,8 @@ validate_user_choice(State, name) ->
     case {Interactive, filelib:is_dir(ProjectPath)} of
         {true, true} ->
             Prompt = io_lib:format(
-                       "A directory with the name ~p already exists."
-                       ++ "Do you wish to proceed ?",
+                       "A directory with the name ~p already exists. "
+                       ++ "Do you wish to proceed? ",
                        [ProjectName]),
             UserChoice = grisp_tools_io:ask(State, Prompt, boolean, false),
             case UserChoice of

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -70,12 +70,21 @@ get(integer, String) ->
         Integer ->
             Integer
     end;
+get(latin1, []) ->
+    no_data;
+get(latin1, Data) ->
+    case io_lib:latin1_char_list(Data) of
+        true ->
+            Data;
+        false ->
+            no_clue
+    end;
 get(string, []) ->
     no_data;
 get(string, String) ->
     case is_list(String) of
         true ->
-            String;
+            unicode:characters_to_binary(String);
         false ->
             no_clue
     end.

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -42,6 +42,8 @@ default(false) ->
     "(y/N)";
 default(true) ->
     "(Y/n)";
+default(Default) when is_list(Default) ->
+    [" (", Default , ")"];
 default(Default) ->
     [" (", io_lib:format("~p", [Default]) , ")"].
 


### PR DESCRIPTION
In this PR, quotes are removed from the default prompt. This could create confusion for the user on the format of the input they had to give.
Some wording in the prompt also have been improved.
This PR is linked to the one on `rebar3_grisp`: https://github.com/grisp/rebar3_grisp/pull/80