### PR TITLE
SEA-265 Improvement of configure task

### DIFF
--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -4,24 +4,27 @@
 -export([run/1]).
 -export([settings/0]).
 
+%--- Record --------------------------------------------------------------------
+-record(set_opts, {prompt            :: string(),
+                   long              :: atom(),
+                   short = undefined :: char() | undefined,
+                   type              :: setting_type(),
+                   default = none    :: none | string() | boolean(),
+                   description       :: string(),
+                   dep_setting_fun   :: function(),
+                   hint  = ""        :: string()}).
+
 %--- Types ---------------------------------------------------------------------
+-type setting_type() :: string | trim_string | boolean | latin1.
 
-% {Name, {Long, Short}, {Type, Default}, Description}
--type settings() :: {string(),
-                     {string(), char()},
-                     {string, string()}
-                     | {boolean, boolean()}
-                     | {latin1, string()},
-                     string()}.
+% @doc {Long, Short, Type, Default, Descr}
+-type setting() :: {atom(),
+                    char() | undefined,
+                    string(),
+                    {setting_type(), string() | boolean()},
+                    string()}.
 
--type settings_options() :: {string(),
-                             {string(), char()},
-                             {string, string()}
-                             | {boolean, boolean()}
-                             | {latin1, string()},
-                             string(),
-                             function()} | settings().
-
+-type set_opts() :: #set_opts{}.
 %--- API -----------------------------------------------------------------------
 
 run(State) ->
@@ -31,8 +34,8 @@ run(State) ->
 do_ask(State, Options) ->
     lists:foldl(
         fun(Setting, AccState) ->
+            Key = Setting#set_opts.long,
             AccState1 = ask(AccState, Setting),
-            {Key, _} = element(2, Setting),
             case validate_user_choice(AccState1, Key) of
                 {ok, AccState2} -> AccState2;
                 {error, _} = E -> grisp_tools_util:event(AccState1, E)
@@ -43,29 +46,38 @@ do_ask(State, Options) ->
 
 ask(#{flags := #{interactive := false}} = State, _) ->
     State; % Skipping ask in non-interactive mode
-ask(#{user_opts := UserOpts} = State, {_, {Key, _}, _, _})
-  when is_map_key(Key, UserOpts) ->
-    user_provided_event(State, Key, UserOpts),
+ask(#{user_opts := UOpts} = State, #set_opts{long = Key, dep_setting_fun = Fun})
+  when is_map_key(Key, UOpts) andalso Fun == undefined ->
+    user_provided_event(State, Key, UOpts),
     State; % Skipping if user provided the option in the command args
-ask(#{user_opts := UOpts, flags := Flags} = State, {_, {Key, _}, _, _, OptsGen})
+ask(#{user_opts := UOpts, flags := Flags}=State, #set_opts{long=Key} = Setting)
   when is_map_key(Key, UOpts) ->
+    OptsGen = Setting#set_opts.dep_setting_fun,
     user_provided_event(State, Key, UOpts),
     case maps:get(Key, UOpts) of
         true -> do_ask(State#{flags := Flags#{Key => true}}, OptsGen());
         _ -> State
     end;
-ask(#{flags := Flags} = State, {Prompt, {Key, _}, {Type, _}, _}) ->
+ask(#{flags := Flags} = State, #set_opts{dep_setting_fun = undefined} = Set) ->
+    Prompt = Set#set_opts.prompt,
+    Key = Set#set_opts.long,
+    Type = Set#set_opts.type,
+    Hint = Set#set_opts.hint,
     Default = maps:get(Key, Flags),
-    Value = grisp_tools_io:ask(State, Prompt, Type, Default),
+    Value = grisp_tools_io:ask(State, Prompt, Type, Default, Hint),
     State#{flags => Flags#{Key => Value}};
-ask(#{flags := Flags} = State, {Prompt, {Key, _}, {boolean, _}, _, OptsGen}) ->
+ask(#{flags := Flags} = State, #set_opts{type = boolean} = Setting) ->
+    Prompt = Setting#set_opts.prompt,
+    Key = Setting#set_opts.long,
+    OptsGen = Setting#set_opts.dep_setting_fun,
+    Hint = Setting#set_opts.hint,
     Default = maps:get(Key, Flags),
-    case grisp_tools_io:ask(State, Prompt, boolean, Default) of
+    case grisp_tools_io:ask(State, Prompt, boolean, Default, Hint) of
         true -> do_ask(State#{flags := Flags#{Key => true}}, OptsGen());
         _ -> State#{flags := Flags#{Key => false}}
     end.
 
-user_provided_event(State, {Key, _}, UserOpts) ->
+user_provided_event(State, Key, UserOpts) ->
     Value = maps:get(Key, UserOpts),
     Prompt = io_lib:format("Value ~p provided for ~p. Skipping question",
                            [Value, Key]),
@@ -96,76 +108,104 @@ validate_user_choice(State, name) ->
 validate_user_choice(State, _Param) ->
     {ok, State}.
 
--spec settings() -> [settings()].
+% @doc The parameters defined directly inside this function won't be ask in
+%      the interactive part of the CLI
+-spec settings() -> [setting()].
 settings() ->
     {{Year, _, _}, _} = calendar:universal_time(),
     {AuthorName, AuthorEmail} = default_author_and_email(),
-    [{"Interactive", {interactive, $i}, {boolean, true},
-      "Activates the interactive mode"},
-     {"Description", {desc, undefined}, {string, "A GRiSP application"},
+    [{interactive, $i, {boolean, true}, "Activates the interactive mode"},
+     {desc, undefined, {string, "A GRiSP application"},
       "Short description of the app"},
-     {"Copyright year", {copyright_year, undefined},
-      {string, integer_to_list(Year)}, "The copyright year"},
-     {"Author name", {author_name, undefined}, {string, AuthorName},
-      "The name of the author"},
-     {"Author email", {author_email, undefined}, {string, AuthorEmail},
-      "The email of the author"}
+     {copyright_year, undefined, {string, integer_to_list(Year)},
+      "The copyright year"},
+     {author_name, undefined, {string, AuthorName}, "The name of the author"},
+     {author_email, undefined, {string, AuthorEmail}, "The emal of the author"}
     ] ++ format_settings_options(settings_options(), []).
 
--spec settings_options() -> [settings_options()].
-settings_options() -> [
-    {"App name", {name, undefined}, {latin1, "robot"},
-     "The name of the OTP application"},
-    {"Erlang version", {otp_version, $o}, {string, "25"},
-     "The OTP version of the GRiSP app"},
-    {"SD Card Path", {dest, $d}, {string, "/path/to/SD-card"},
-     "The path to the SD card where you want to deploy the GRISP app"},
-    {"Use Network ?", {network, $n}, {boolean, false},
-     "Network configuration files generation", fun network_options/0}
-].
+% @doc the settings given in this function and in all the extension functions
+%      of boolean settings will be used during the interactive part of the CLI
+-spec settings_options() -> [set_opts()].
+settings_options() ->
+    [#set_opts{prompt = "App name", long = name, type = latin1, default="robot",
+              description = "The name of the OTP application",
+              hint = "Enter the name of your application"},
+     #set_opts{prompt = "Erlang version", long = otp_version, short = $o,
+              type = string, default = "25",
+              description = "The OTP version of the GRiSP app",
+              hint = "Specify the Erlang version to use"},
+     #set_opts{prompt = "SD Card path", long = dest, short = $d, type = string,
+              default = "/path/to/SD-card",
+              description = "The path to the SD card where you want to deploy "
+                            ++ "the GRiSP app",
+              hint = "Define the path to the SD card where the application "
+                     ++ "will be deployed."},
+     #set_opts{prompt = "Use network ?", long = network, short=$n, type=boolean,
+              default = false, dep_setting_fun = fun network_options/0,
+              description = "Network configuration files generation"}].
 
--spec network_options() -> [settings_options()].
+-spec network_options() -> [set_opts()].
 network_options() -> [
-    {"Use Wi-Fi ?", {wifi, $w}, {boolean, false},
-     "Wifi configuration", fun wifi_options/0},
-    {"Enable GRiSP.io integration ?", {grisp_io, $g}, {boolean, false},
-     "GRiSP.io configuration", fun grisp_io_options/0},
-    {"Enable Distributed Erlang ?", {epmd, $e}, {boolean, false},
-     "Distributed Erlang configuration generation", fun epmd_options/0}
-].
+    #set_opts{prompt = "Use Wi-Fi ?", long = wifi, short = $w, type = boolean,
+             default = false, description = "Wi-Fi configuration",
+             dep_setting_fun = fun wifi_options/0,
+             hint = "If you want to use ethernet press 'n'"},
+    #set_opts{prompt = "Enable GRiSP.io integration ?", long = grisp_io,
+             short = $g, type = boolean, default = false,
+             description = "GRiSP.io configuration",
+             dep_setting_fun = fun grisp_io_options/0},
+    #set_opts{prompt = "Enable Distributed Erlang ?", long = epmd, short = $e,
+             type = boolean, default = false,
+             description = "Distributed Erlang configuraiton generation",
+             hint = "If you want to use the remote shell press 'y'",
+             dep_setting_fun = fun epmd_options/0}].
 
--spec wifi_options() -> [settings_options()].
+-spec wifi_options() -> [set_opts()].
 wifi_options() -> [
-    {"Wi-Fi SSID", {ssid, $p}, {string, "My Wifi"}, "The SSID of your Wi-Fi"},
-    {"Wi-Fi Password", {psk, $p}, {string, "..."}, "The PSK of your Wi-Fi"}
-].
+    #set_opts{prompt = "Wi-Fi SSID", long = ssid, short = $p, type = string,
+             description = "The SSID of your Wi-Fi", hint = "Your Wi-Fi name"},
+    #set_opts{prompt = "Wi-Fi password", long = psk, short = $p, type = string,
+             description = "The PSK of your Wi-Fi", hint = "Your password"}].
 
--spec grisp_io_options() -> [settings_options()].
+-spec grisp_io_options() -> [set_opts()].
 grisp_io_options() -> [
-    {"Do you need to link your GRiSP-2 board ?", {grisp_io_linking, $l},
-     {boolean, false}, "GRiSP.io device linking", fun grisp_io_link_options/0}
-].
+    #set_opts{prompt =  "Do you need to link your GRiSP-2 board ?", short = $l,
+             long = grisp_io_linking, type = boolean, default = false,
+             description = "GRiSP.io device linking",
+             dep_setting_fun = fun grisp_io_link_options/0}].
 
--spec grisp_io_link_options() -> [settings_options()].
+-spec grisp_io_link_options() -> [set_opts()].
 grisp_io_link_options() -> [
-    {"Please enter your personal device linking token", {token, $t},
-     {trim_string, "..."}, "Your private GRiSP.io token"}
-].
+    #set_opts{prompt = "Please enter your personal device linking token",
+             long = token, short = $t, type = trim_string,
+             description = "Your private GRiSP.io token",
+             hint = "# Write the token without any <, > or "}].
 
--spec epmd_options() -> [settings_options()].
+-spec epmd_options() -> [set_opts()].
 epmd_options() -> [
-    {"Erlang Cookie", {cookie, $c}, {string, "grisp"},
-     "The distributed Erlang cookie"}
-].
+    #set_opts{prompt = "Erlang Cookie", long = cookie, short = $c, type=string,
+             default = "grisp", description = "The distributed Erlang cookie",
+             hint = "Cookie is necessary for remote shell."}].
 
--spec format_settings_options([settings_options()], [settings()]) -> settings().
+-spec format_settings_options([set_opts()], [setting()]) -> setting().
 format_settings_options([], Acc) ->
     Acc;
-format_settings_options([{_, _, _, _} = Opt | Tail], Acc) ->
-    format_settings_options(Tail, [Opt | Acc]);
-format_settings_options([{Prompt, Key, Type, Descr, FollowUp} | Tail], Acc) ->
+format_settings_options([#set_opts{dep_setting_fun = undefined} = O |T], Acc) ->
+    Long = O#set_opts.long,
+    Short = O#set_opts.short,
+    Type = O#set_opts.type,
+    Default = O#set_opts.default,
+    Descr = O#set_opts.description,
+    format_settings_options(T, [{Long, Short, {Type, Default}, Descr} | Acc]);
+format_settings_options([SetOpts | Tail], Acc) ->
+    Long = SetOpts#set_opts.long,
+    Short = SetOpts#set_opts.short,
+    Type = SetOpts#set_opts.type,
+    Descr = SetOpts#set_opts.description,
+    Default = SetOpts#set_opts.default,
+    FollowUp = SetOpts#set_opts.dep_setting_fun,
     format_settings_options(Tail ++ FollowUp(),
-                            [{Prompt, Key, Type, Descr} | Acc]).
+                            [{Long, Short, {Type, Default}, Descr} | Acc]).
 
 default_author_and_email() ->
     %% See if we can get a git user and email to use as defaults

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -179,7 +179,7 @@ grisp_io_link_options() -> [
     #set_opts{prompt = "Please enter your personal device linking token",
              long = token, short = $t, type = trim_string,
              description = "Your private GRiSP.io token",
-             hint = "# Write the token without any <, > or "}].
+             hint = "Write the token without any <, > or "}].
 
 -spec epmd_options() -> [set_opts()].
 epmd_options() -> [

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -179,7 +179,7 @@ grisp_io_link_options() -> [
     #set_opts{prompt = "Please enter your personal device linking token",
              long = token, short = $t, type = trim_string,
              description = "Your private GRiSP.io token",
-             hint = "Write the token without any <, > or "}].
+             hint = "Write the token without any <, > or \""}].
 
 -spec epmd_options() -> [set_opts()].
 epmd_options() -> [

--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -149,7 +149,7 @@ grisp_io_options() -> [
 -spec grisp_io_link_options() -> [settings_options()].
 grisp_io_link_options() -> [
     {"Please enter your personal device linking token", {token, $t},
-     {string, "..."}, "Your private GRiSP.io token"}
+     {trim_string, "..."}, "Your private GRiSP.io token"}
 ].
 
 -spec epmd_options() -> [settings_options()].

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -19,17 +19,19 @@ ask(State, Prompt, Type, Default, Hint)  ->
 
 %--- Internal ------------------------------------------------------------------
 
-ask_convert(State, Prompt, TransFun, Type,  Default, Hint) ->
+ask_convert(State0, Prompt, TransFun, Type,  Default, Hint) ->
     DefaultPrompt = erlang:iolist_to_binary(
         ["\n", hint(Hint), Prompt, default(Default), "> "]
     ),
     NewPrompt = erlang:binary_to_list(DefaultPrompt),
-    Data = trim(trim(io:get_line(NewPrompt)), both, [$\n]),
+    Event = {ask, NewPrompt},
+    {RawUserInput, State1} = grisp_tools_util:event_with_result(State0, Event),
+    Data = trim(trim(RawUserInput), both, [$\n]),
     case TransFun(Type, Data)  of
         no_data ->
-            maybe_continue(State, Prompt, TransFun, Type, Default, Hint);
+            maybe_continue(State1, Prompt, TransFun, Type, Default, Hint);
         no_clue ->
-            continue(State, Prompt, TransFun, Type, Default, Hint);
+            continue(State1, Prompt, TransFun, Type, Default, Hint);
         Ret ->
             Ret
     end.

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -64,7 +64,7 @@ default(Default) ->
 hint("") ->
     "";
 hint(Hint) ->
-    [color(242, Hint), "\n"].
+    [color(242, "# " ++ Hint), "\n"].
 
 get(boolean, []) ->
     no_data;

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -79,6 +79,16 @@ get(latin1, Data) ->
         false ->
             no_clue
     end;
+get(trim_string, []) ->
+    no_data;
+get(trim_string, String) ->
+    case is_list(String) of
+        true ->
+            Trimmed = string:trim(String),
+            unicode:characters_to_binary(Trimmed);
+        false ->
+            no_clue
+    end;
 get(string, []) ->
     no_data;
 get(string, String) ->
@@ -98,11 +108,6 @@ trim(Str) -> string:strip(rebar_utils:to_list(Str)).
 trim(Str, Dir, [Chars|_]) -> string:strip(rebar_utils:to_list(Str), Dir, Chars).
 -endif.
 
-say(State, Say) ->
-    Event = {say, io_lib:format(lists:flatten([Say, "~n"]), [])},
-    grisp_tools_util:event(State, Event).
-
--spec say(string(), [term()] | term()) -> ok.
 say(State, Say, Args) when is_list(Args) ->
     Event = {say, io_lib:format(lists:flatten([Say, "~n"]), Args)},
     grisp_tools_util:event(State, Event);

--- a/src/grisp_tools_io.erl
+++ b/src/grisp_tools_io.erl
@@ -56,10 +56,10 @@ default(false) ->
 default(true) ->
     color(51, " (Y/n)");
 default(Default) when is_list(Default) ->
-    DefaultText = io_lib:format(" (default: ~p)", [Default]),
+    DefaultText = io_lib:format(" (default: ~s)", [Default]),
     color(51, DefaultText);
 default(Default) ->
-    color(51, io_lib:format("(~p)", [Default])).
+    color(51, io_lib:format("(~s)", [Default])).
 
 hint("") ->
     "";
@@ -103,7 +103,8 @@ get(trim_string, []) ->
 get(trim_string, String) ->
     case is_list(String) of
         true ->
-            Trimmed = string:trim(String),
+            Whitespace = unicode_util:whitespace(),
+            Trimmed = string:trim(String, both, Whitespace ++ [$"]),
             unicode:characters_to_binary(Trimmed);
         false ->
             no_clue

--- a/src/grisp_tools_util.erl
+++ b/src/grisp_tools_util.erl
@@ -3,6 +3,7 @@
 % API
 -export([weave/2]).
 -export([event/2]).
+-export([event_with_result/2]).
 -export([shell/2]).
 -export([shell/3]).
 -export([exec/3]).
@@ -71,6 +72,11 @@ event(#{event_stack := Stack} = State0, Events) when is_list(Events) ->
 event(State0, Event) -> % TODO: Remove this clause
     {_Result, State1} = exec(event, State0, [Event]),
     State1.
+
+event_with_result(#{event_stack := Stack} = State0, Events) when is_list(Events) ->
+    exec(event, State0, [Stack ++ Events]);
+event_with_result(State0, Event) ->
+    exec(event, State0, [Event]).
 
 shell(State, Command) -> shell(State, Command, []).
 


### PR DESCRIPTION
### Summary
This PR is linked to the PR [SEA-265 Improvement of configure task](https://github.com/grisp/rebar3_grisp/pull/81) on `rebar3_grisp` 

In this PR a few improvements have been done for the `configure` task:
* The grisp.io token is now trimmed at the beginning and at the end of the user input
* A setting was represented as a tuple internally. It is now represented as a record
* Some prompts now have hint/comments to explain them. They are displayed on top of the actual prompt. They are optional
* The default values are displayed in blue. The comments are displayed in grey and warnings are displayed in orange
* Internally, asking for an input is done through an event. This wasn't the case before

### How to test ?
To test this PR you will need a local setup. Indeed, since the changes aren't pushed on the main branch the version of the plugin globally installed on your computer won't reflect the changes made for this PR. Thus we will need to use a throw off grisp project and use the _checkouts folder to use the correct versions of this repo as well as the [rebar3_grisp](https://github.com/grisp/rebar3_grisp) repo. Both of them should be setup to checkout the branch named SEA-365-grisp-conf-upgrade

### Example of the overall look of the task
![Screenshot 2024-06-04 at 15 13 47](https://github.com/grisp/grisp_tools/assets/44499033/7c6e0241-19bf-4276-b7c5-bbc7d56c6a06)
