### PR TITLE
Add --rm to cleanup docker containers after command execution

### DIFF
--- a/src/grisp_tools_build.erl
+++ b/src/grisp_tools_build.erl
@@ -270,6 +270,7 @@ dockerize_command(Cmd, S0) ->
     {docker, Image} = mapz:deep_get([paths, toolchain], S0),
     BuildSubdir = string:prefix(BuidPath, Cwd),
     ["docker run",
+    " --rm ",
     [" -e " ++ K ++ "=" ++ io_lib:format("~s",[V])|| {K,V} <- maps:to_list(Env)],
     " --volume " ++ Cwd ++ ":" ++ Cwd,
     " " ++ Image ++ " sh -c \"cd " ++ Cwd ++ BuildSubdir,


### PR DESCRIPTION
We do not recycle docker containers and currently every dockerized_command call will create a new container.
This makes docker remove the container as soon as it returns.