### PR TITLE
Insert  key to normalize toolchain maps results

### DIFF
--- a/src/grisp_tools_package.erl
+++ b/src/grisp_tools_package.erl
@@ -135,7 +135,8 @@ parse_toolchain(#{name := Name} = File, {Acc, Latest}) ->
             NewFile = File#{
                 os => OS,
                 os_version => OSVsn,
-                revision => Revision
+                revision => Revision,
+                latest => false
             },
             {[NewFile|Acc], Latest}
     end.


### PR DESCRIPTION
In rebar3_grisp we upgraded grid which now crashes if a value is not present in the map.

With this change the `latest` key is always returned.