### PR TITLE
Bump Ubuntu version to let CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         env:
           cache-name: rebar3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         rebar3: ['3']
         # latest rebar3 versions that do not give problems with selected OTPs
         include:
-          - otp: '23'
-            rebar3: '3.20.0'
           - otp: '24'
             rebar3: '3.23.0'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:


### PR DESCRIPTION
The CI workflow was using a deprecated version of Ubuntu (see: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)

This PR bumps the version of Ubuntu to 24.04

I also had to bump the version of cache from v2 to v4.

Furthermore, Ubuntu 24.04 doesn't support OTP23 so I had to drop it from the CI runs as well (see: https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp)