### PR TITLE
Suggest OTP 28 as default

### DIFF
--- a/src/grisp_tools_configure.erl
+++ b/src/grisp_tools_configure.erl
@@ -131,7 +131,7 @@ settings_options() ->
               description = "The name of the OTP application",
               hint = "Enter the name of your application"},
      #set_opts{prompt = "Erlang version", long = otp_version, short = $o,
-              type = string, default = "25",
+              type = string, default = "28",
               description = "The OTP version of the GRiSP app",
               hint = "Specify the Erlang version to use"},
      #set_opts{prompt = "SD Card path", long = dest, short = $d, type = string,


### PR DESCRIPTION
Because we want to push latest OTPs it makes sense to move onward.


Since grisp_cryptoauth 2.6.0 there are no issues with OTP 28, so IMO, this new default is a valid suggestion.